### PR TITLE
Add Support of PreparsedDocumentProvider Bean to  DgsWebFluxAutoConfiguration.

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -85,7 +85,7 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
         @Qualifier("query") providedQueryExecutionStrategy: Optional<ExecutionStrategy>,
         @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
         idProvider: Optional<ExecutionIdProvider>,
-        reloadSchemaIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator
+        reloadSchemaIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator,
         preparsedDocumentProvider: PreparsedDocumentProvider
     ): DgsReactiveQueryExecutor {
 

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -39,6 +39,7 @@ import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.introspection.IntrospectionQuery
 import graphql.schema.GraphQLSchema
 import org.springframework.beans.factory.annotation.Qualifier
@@ -85,6 +86,7 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
         @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
         idProvider: Optional<ExecutionIdProvider>,
         reloadSchemaIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator
+        preparsedDocumentProvider: PreparsedDocumentProvider
     ): DgsReactiveQueryExecutor {
 
         val queryExecutionStrategy =
@@ -100,7 +102,8 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
             queryExecutionStrategy,
             mutationExecutionStrategy,
             idProvider,
-            reloadSchemaIndicator
+            reloadSchemaIndicator,
+            preparsedDocumentProvider
         )
     }
 


### PR DESCRIPTION
Please refer to https://github.com/Netflix/dgs-framework/issues/50. Support of PreparsedDocumentProvider was added through https://github.com/Netflix/dgs-framework/pull/583. 
Above PR added it to DefaultDgsReactiveQueryExecutor but missed changes in DgsWebFluxAutoConfiguration. 
In this PR, we are fixing that so that WebFlux application can define own implementation PreparsedDocumentProvider. 